### PR TITLE
Anonymize mrxs metadata and generate Windows .exe

### DIFF
--- a/anonymize_slide.py
+++ b/anonymize_slide.py
@@ -599,17 +599,8 @@ def do_aperio_svs(filename):
     with TiffFile(filename) as fh:
         # Find and delete label
         for directory in fh.directories:
-            
-            # for key in directory.entries.keys():
-            #     print('ENTRY: ', directory.entries[key].value()[:10])
-            
             lines = directory.entries[IMAGE_DESCRIPTION].value().splitlines()
-            if lines[0].startswith(b'Aperio'):
-                
-                if lines[1].find(b"Q=100") > -1:
-                    directory.delete()
-
-            elif len(lines) >= 2 and lines[1].startswith(b'label '):
+            if len(lines) >= 2 and lines[1].startswith(b'label '):
                 # directory.delete(expected_prefix=LZW_CLEARCODE)
                 directory.delete()
                 print("Deleted label.")

--- a/anonymize_slide.py
+++ b/anonymize_slide.py
@@ -35,6 +35,7 @@ from io import StringIO
 from glob import glob
 from optparse import OptionParser
 import os
+import re
 # import string
 import struct
 import subprocess
@@ -330,8 +331,10 @@ class MrxsFile(object):
 
         # Parse slidedat
         self._slidedatfile = os.path.join(dirname, 'Slidedat.ini')
+        self._slidedatfile_upperdir = os.path.join(dirname, '../Slidedat.ini')
         self._dat = RawConfigParser()
         self._dat.optionxform = str
+        self._anonymize_meta(dirname)
         try:
             with open(self._slidedatfile, 'r', encoding="utf-8-sig") as fh:
                 self._have_bom = (fh.read(len(UTF8_BOM)) == UTF8_BOM)
@@ -350,6 +353,20 @@ class MrxsFile(object):
 
         # Build levels
         self._make_levels()
+
+    def _anonymize_meta(self, dirname):
+        for filename in [os.path.join(dirname, 'Slidedat.ini'), os.path.join(dirname, '../Slidedat.ini')]:
+            filedata = ''
+            with open(filename, 'r') as fh:
+                filedata = fh.read()
+                filedata = re.sub(r"SLIDE_NAME.*", "SLIDE_NAME = None", filedata)
+                filedata = re.sub(r"PROJECT_NAME.*", "PROJECT_NAME = None", filedata)
+                filedata = re.sub(r"SLIDE_CREATIONDATETIME.*", "SLIDE_CREATIONDATETIME = None", filedata)
+                fh.close
+
+            with open(filename, 'w') as fh:
+                fh.write(filedata)
+                fh.close()
 
     def _make_levels(self):
         self._levels = {}

--- a/anonymize_slide.py
+++ b/anonymize_slide.py
@@ -668,10 +668,10 @@ def do_ventana_tif(filename):
 
 
 format_handlers = [
-    do_ventana_tif,
-    do_aperio_svs,
-    do_hamamatsu_ndpi,
     do_3dhistech_mrxs,
+    do_hamamatsu_ndpi,
+    do_aperio_svs,
+    do_ventana_tif,
 ]
 
 def anonymize_slide(filename):


### PR DESCRIPTION
I implemented the anonymization of mrxs metadata (fields SLIDE_NAME, PROJECT_NAME and CREATION_DATETIME). 

Also I generated an .exe file. To do so I had to change the order of the format handlers since the file could not be found after the ventana handler opened and closed it (only happens with the .exe, not with the python script). To anonymize the files just drag and drop them on the .exe. It would be great if you could test the .exe as well (including your ventana files).